### PR TITLE
Issue#51 Fix flickering issue in dark mode during website load

### DIFF
--- a/apps/docs/src/components/work-in-progress/index.tsx
+++ b/apps/docs/src/components/work-in-progress/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 function Wip() {
   return (
-    <div className="fixed z-40 px-2 py-0.5 bottom-2 bg-gray-100 border-medusa-tag-neutral-border border border-solid rounded shadow-none duration-150 cursor-progress hover:scale-105 right-2">
+    <div className="fixed z-40 px-2 py-0.5 bottom-2 bg-gray-100 dark:bg-neutral-800 border-medusa-tag-neutral-border border border-solid rounded shadow-none duration-150 cursor-progress hover:scale-105 right-2">
       🚧 Work in Progress
     </div>
   );

--- a/packages/docs-ui/src/providers/ColorMode/index.tsx
+++ b/packages/docs-ui/src/providers/ColorMode/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useLayoutEffect, useState } from 'react';
 
 export type ColorMode = 'light' | 'dark';
 
@@ -23,7 +23,7 @@ export const ColorModeProvider = ({ children }: ColorModeProviderProps) => {
   const toggleColorMode = () =>
     setColorMode(colorMode === 'light' ? 'dark' : 'light');
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (loaded) {
       return;
     }
@@ -31,8 +31,10 @@ export const ColorModeProvider = ({ children }: ColorModeProviderProps) => {
     const theme = localStorage.getItem('theme');
     if (theme && (theme === 'light' || theme === 'dark')) {
       setColorMode(theme);
-      setLoaded(true);
+    } else {
+      setColorMode("light") //if no value in localstorage present
     }
+    setLoaded(true);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
#### What Type of Change is this?

- [ ] New Page
- [x] Minor Fix
- [ ] Minor Improvement
- [ ] Major Improvement

#### Description (required)

Previously, the `useEffect` hook was used on every page load to check the theme value from `localStorage` and update the theme accordingly. Since `useEffect` runs after the initial page render, this caused a flicker during page reloads.

I replaced `useEffect` with `useLayoutEffect`, which runs before the initial render, resolving the flicker issue.

#### Related issues & labels (optional)

- Closes #51
