### PR TITLE
chore: added example with php.ini values in env variables

### DIFF
--- a/apps/docs/content/php/how-to/customize-runtime.mdx
+++ b/apps/docs/content/php/how-to/customize-runtime.mdx
@@ -55,13 +55,18 @@ When the custom runtime cache is used, Zerops doesn't create a prepare runtime c
 
 You can override PHP configuration directives by setting environment variables in your `zerops.yml` file.
 
-For example, to adjust PHP's maximum POST size limit, you would set the `post_max_size` directive like this:
+Here's an example of how to adjust PHP's `post_max_size` directive:
 
 ```yml
 zerops:
+  # define hostname of your service
   - setup: app
+    # ==== how to build your application ====
     run:
+      # REQUIRED. Sets the base technology for the build environment:
       base: php-nginx@8.3
+
+      # OPTIONAL. Defines the env variables for the build environment:
       envVariables:
         PHP_INI_post_max_size: 10M
 ```

--- a/apps/docs/content/php/how-to/customize-runtime.mdx
+++ b/apps/docs/content/php/how-to/customize-runtime.mdx
@@ -50,3 +50,15 @@ To invalidate the custom runtime cache go to `yyy`
 **// TODO screenshot**
 
 When the custom runtime cache is used, Zerops doesn't create a prepare runtime container and executes the deployment of your application directly.
+
+### Example
+
+```yml
+zerops:
+  - setup: app
+    run:
+      base: php-nginx@8.3
+      envVariables:
+        # It is possible to overwrite php.ini values using env variables
+        PHP_INI_post_max_size: 10M
+```

--- a/apps/docs/content/php/how-to/customize-runtime.mdx
+++ b/apps/docs/content/php/how-to/customize-runtime.mdx
@@ -51,7 +51,11 @@ To invalidate the custom runtime cache go to `yyy`
 
 When the custom runtime cache is used, Zerops doesn't create a prepare runtime container and executes the deployment of your application directly.
 
-### Example
+### Overwrite php.ini files
+
+You can override PHP configuration directives by setting environment variables in your `zerops.yml` file.
+
+For example, to adjust PHP's maximum POST size limit, you would set the `post_max_size` directive like this:
 
 ```yml
 zerops:
@@ -59,6 +63,6 @@ zerops:
     run:
       base: php-nginx@8.3
       envVariables:
-        # It is possible to overwrite php.ini values using env variables
+        # php.ini values can be overwritten using env variables
         PHP_INI_post_max_size: 10M
 ```

--- a/apps/docs/content/php/how-to/customize-runtime.mdx
+++ b/apps/docs/content/php/how-to/customize-runtime.mdx
@@ -63,6 +63,5 @@ zerops:
     run:
       base: php-nginx@8.3
       envVariables:
-        # php.ini values can be overwritten using env variables
         PHP_INI_post_max_size: 10M
 ```


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Page
- [ ] Minor Fix
- [x] Minor Improvement
- [ ] Major Improvement

#### Description (required)
added example to showcase overwriting php.ini values in ``customize-runtime.mdx`` for PHP

```yml
zerops:
  - setup: app
    run:
      base: php-nginx@8.3
      envVariables:
        # It is possible to overwrite php.ini values using env variables
        PHP_INI_post_max_size: 10M
```

<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
