### PR TITLE
fix: misleading ``.deployignore`` path

### DIFF
--- a/apps/docs/content/bun/how-to/build-pipeline.mdx
+++ b/apps/docs/content/bun/how-to/build-pipeline.mdx
@@ -303,6 +303,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -349,22 +351,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `node_modules` folder in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-node_modules;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/deno/how-to/build-pipeline.mdx
+++ b/apps/docs/content/deno/how-to/build-pipeline.mdx
@@ -296,6 +296,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -342,22 +344,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `node_modules` folder in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-node_modules;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/dotnet/how-to/build-pipeline.mdx
+++ b/apps/docs/content/dotnet/how-to/build-pipeline.mdx
@@ -298,6 +298,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -344,22 +346,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `src/file.txt` file in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-src / file.txt;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/elixir/how-to/build-pipeline.mdx
+++ b/apps/docs/content/elixir/how-to/build-pipeline.mdx
@@ -299,6 +299,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -345,22 +347,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `node_modules` folder in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-node_modules;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/gleam/how-to/build-pipeline.mdx
+++ b/apps/docs/content/gleam/how-to/build-pipeline.mdx
@@ -300,6 +300,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -346,22 +348,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `node_modules` folder in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-node_modules;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/go/how-to/build-pipeline.mdx
+++ b/apps/docs/content/go/how-to/build-pipeline.mdx
@@ -292,6 +292,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -338,22 +340,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `src/file.txt` file in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-src / file.txt;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/java/how-to/build-pipeline.mdx
+++ b/apps/docs/content/java/how-to/build-pipeline.mdx
@@ -292,6 +292,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -338,22 +340,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `src/file.txt` file in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-src / file.txt;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/nodejs/how-to/build-pipeline.mdx
+++ b/apps/docs/content/nodejs/how-to/build-pipeline.mdx
@@ -301,6 +301,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -347,22 +349,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `node_modules` folder in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-node_modules;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/php/how-to/build-pipeline.mdx
+++ b/apps/docs/content/php/how-to/build-pipeline.mdx
@@ -296,6 +296,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -342,22 +344,39 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `src/file.txt` file in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-src / file.txt;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/python/how-to/build-pipeline.mdx
+++ b/apps/docs/content/python/how-to/build-pipeline.mdx
@@ -250,6 +250,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -295,22 +297,40 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 deployFiles: ./path/~/to/
 ```
 
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
+
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `src/file.txt` file in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-src / file.txt;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/references/cli/commands.mdx
+++ b/apps/docs/content/references/cli/commands.mdx
@@ -205,6 +205,8 @@ zcli service {sub-command} [arguments] [flags]
   - `--workingDir <path>`: Sets a custom working directory (default: `./`)
   - `--zeropsYamlPath <path>`: Specifies a custom path to the `zerops.yml` file
 
+  See how to use [.deployignore](/zerops-yml/specification#deployignore) file.
+
 - `enable-subdomain`
 
   - `--projectId <id>`: Required if you have access to multiple projects
@@ -238,23 +240,6 @@ zcli service {sub-command} [arguments] [flags]
 - `stop`
   - `--projectId <id>`: Required if you have access to multiple projects
   - `--serviceId <id>`: Required if you have access to multiple services
-
-#### .deployignore
-
-Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax is the same as a `.gitignore` file.
-
-Example to ignore `src/file.txt` file in deploy:
-
-```jsx title="zerops.yml"
-zerops:
-  - setup: app
-    build:
-      deployFiles: ./
-```
-
-```jsx title=".deployignore"
-src / file.txt;
-```
 
 ---
 

--- a/apps/docs/content/rust/how-to/build-pipeline.mdx
+++ b/apps/docs/content/rust/how-to/build-pipeline.mdx
@@ -291,6 +291,8 @@ Determines files or folders produced by your build, which should be deployed to 
 
 The path starts from the **root directory** of your project (the location of `zerops.yml`). You must enclose the name in quotes if the folder or the file name contains a space.
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Examples
 
 Deploys a folder, and a file from the project root directory:
@@ -335,23 +337,40 @@ Deploys all folders that are located in any path that begins with `/path/` and e
 ```yml
 deployFiles: ./path/~/to/
 ```
+:::note Example
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
+:::
 
 #### .deployignore
 
-Add a `.deployignore` file to the root of your project and specify which files and folders Zerops should ignore during deploy. The syntax is the same as of a <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a> file.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
 
-Example to ignore `src/file.txt` file in deploy:
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
 
-```jsx title="zerops.yml"
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
 zerops:
   - setup: app
     build:
       deployFiles: ./
 ```
 
-```jsx title=".deployignore"
-src / file.txt;
+```text title=".deployignore"
+/src/file.txt
 ```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
 
 :::note
 `.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.

--- a/apps/docs/content/zerops-yml/specification.mdx
+++ b/apps/docs/content/zerops-yml/specification.mdx
@@ -145,11 +145,42 @@ Deploys all `file.txt` files that are located in any path that begins with `/pat
 deployFiles: ./path/~/to/file.txt
 ```
 
-E.g. `./src/assets/~fonts` would result in  `/var/www/fonts` in runtime.
+By default, `./src/assets/fonts` deploys to `/var/www/src/assets/fonts`, keeping the full path. Adding `~`, like `./src/assets/~fonts`, shortens it to `/var/www/fonts`
 
 #### .deployignore
 
-Use a `.deployignore` file to exclude specific files or folders from deployment.
+Add a `.deployignore` file to the root of your project to specify which files and folders Zerops should ignore during deploy. The syntax follows the same pattern format as <a href="https://git-scm.com/docs/gitignore#_pattern_format">`.gitignore`</a>.
+
+To ignore a specific file or directory path, start the pattern with a forward slash (`/`). Without the leading slash, the pattern will match files with that name in any directory.
+
+:::tip
+For consistency, it's recommended to configure both your `.gitignore` and `.deployignore` files with the same patterns.
+:::
+
+Examples:
+
+```yml title="zerops.yml"
+zerops:
+  - setup: app
+    build:
+      deployFiles: ./
+```
+
+```text title=".deployignore"
+/src/file.txt
+```
+The example above ignores `file.txt` only in the root src directory.
+```text title=".deployignore"
+src/file.txt
+```
+This example above ignores `file.txt` in ANY directory named `src`, such as:
+- `/src/file.txt`
+- `/folder2/folder3/src/file.txt`
+- `/src/src/file.txt`
+
+:::note
+`.deployignore` file also works with <a href="/references/cli/commands#deploy">`zcli service deploy`</a> command.
+:::
 
 ### cache <Badge text="Optional" color="blue" />
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Page
- [x] Minor Fix
- [ ] Minor Improvement
- [ ] Major Improvement

#### Description (required)

In Trigger build pipeline pages in all runtimes, there is a ``.deployignore`` [paragraph](https://docs.zerops.io/python/how-to/build-pipeline#deployignore)

The example is slightly misleading. If you put src/file.js in ``.deployignore``, it will ignore (i.e., not deploy) all of the following:
```
/src/file.js
/folder2/folder3/src/file.js
/src/src/file.js
```
The correct approach is for the user to always define files in both ``.gitignore`` and ``.deployignore`` with a / at the beginning if they want to ignore only one specific file and not all files with the same name in all folders.

The "root" folder is considered the build folder, i.e., the folder where the user’s app is located (at the same level as the .deployignore file). This is the correct behaviour.

#### Related issues & labels (optional)

<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
