### PR TITLE
chore: added infobox to deployfiles

### DIFF
--- a/apps/docs/content/zerops-yml/specification.mdx
+++ b/apps/docs/content/zerops-yml/specification.mdx
@@ -133,11 +133,19 @@ build:
     - node_modules
 ```
 
+The files/folders will be placed into `/var/www` folder in runtime, e.g. `./src/assets/fonts` would result in `/var/www/src/assets/fonts`.
+
 #### Using wildcards:
+
+Zerops supports the `~` character as a wildcard for one or more folders in the path.
+
+Deploys all `file.txt` files that are located in any path that begins with `/path/` and ends with `/to/`.
 
 ```yml
 deployFiles: ./path/~/to/file.txt
 ```
+
+E.g. `./src/assets/~fonts` would result in  `/var/www/fonts` in runtime.
 
 #### .deployignore
 


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Page
- [ ] Minor Fix
- [x] Minor Improvement
- [ ] Major Improvement

#### Description (required)

[adding summarised infobox to deployFiles sections for more clarity](https://discord.com/channels/735781031147208777/1317521737210007713/1317522231294820383)

present in all runtime sections, only pending in ``zeropsyml.mdx`` 

![image](https://github.com/user-attachments/assets/c397274a-6ae3-4fa5-a7e4-84dd59aa5b81)

`./src/assets/fonts` would deploy `./src/assets/fonts` placed at `/var/www` in runtime

so `/var/www/src/assets/fonts`

placing `~` on the path, it will deploy from `./src/assets/~fonts`

would result in  `/var/www/fonts`

#### Related issues & labels (optional)


<!-- #### First-time contributor to Zerops Docs? -->

<!-- Join our Discord Server  -->
<!-- https://discord.gg/xxzmJSDKPT -->
