### PR TITLE
fix(docs): Run development on Windows platform

### DIFF
--- a/apps/docs/.content.eslintrc.js
+++ b/apps/docs/.content.eslintrc.js
@@ -1,4 +1,9 @@
 module.exports = {
   root: true,
   extends: ['docs/content'],
+  rules: {
+    'quotes': ['error', 'single'],
+    'semi': ['error', 'always'],
+    'max-len': ['error', { code: 80, ignoreComments: true }]
+  }
 };

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.22.15",
+    "@docusaurus/eslint-plugin": "latest",
     "@docusaurus/module-type-aliases": "latest",
     "@docusaurus/tsconfig": "latest",
     "@docusaurus/types": "latest",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "scripts": {
     "build": "turbo run build --env-mode=loose",
-    "build:docs": "turbo run build --filter=docs",
-    "start": "turbo run start:monorepo",
-    "dev": "turbo run dev:monorepo",
+    "build:docs": "turbo run build --filter=docs --env-mode=loose",
+    "start": "turbo run start:monorepo --env-mode=loose",
+    "dev": "turbo run dev:monorepo --env-mode=loose",
     "format": "prettier . --write",
     "lint": "turbo run lint",
     "lint:content": "turbo run lint:content"
@@ -19,6 +19,7 @@
   "dependencies": {
     "autoprefixer": "10.4.14",
     "eslint": "^8.36.0",
+    "eslint-plugin-prettier": "5.2.3",
     "postcss": "8.4.31",
     "prettier": "3.3.3",
     "tailwindcss": "3.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,6 +1410,14 @@
     "@typescript-eslint/utils" "^5.62.0"
     tslib "^2.6.0"
 
+"@docusaurus/eslint-plugin@latest":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/eslint-plugin/-/eslint-plugin-3.7.0.tgz#bb5a13ba7fffb25cd122bf8d955b00fd4017c994"
+  integrity sha512-Bnmx16acy1cFTkv5onm8kRngU6xETEIqkuka+bH4+gCADnKJewHQ/3CRGjsRaii1M/103NSzGlf8ffQ1k9S04w==
+  dependencies:
+    "@typescript-eslint/utils" "^5.62.0"
+    tslib "^2.6.0"
+
 "@docusaurus/logger@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-3.4.0.tgz#8b0ac05c7f3dac2009066e2f964dee8209a77403"
@@ -2432,6 +2440,11 @@
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@pkgr/core@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
+  integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
 "@pnpm/config.env-replace@^1.1.0":
   version "1.1.0"
@@ -7723,6 +7736,14 @@ eslint-plugin-markdown@^3.0.0:
   integrity sha512-8rqoc148DWdGdmYF6WSQFT3uQ6PO7zXYgeBpHAOAakX/zpq+NvFYbDA/H7PYzHajwtmaOzAwfxyl++x0g1/N9A==
   dependencies:
     mdast-util-from-markdown "^0.8.5"
+
+eslint-plugin-prettier@5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz#c4af01691a6fa9905207f0fbba0d7bea0902cce5"
+  integrity sha512-qJ+y0FfCp/mQYQ/vWQ3s7eUlFEL4PyKfAJxsnYTJ4YT73nsJBWqmEpFryxV9OeUiqmsTsYJ5Y+KDNaeP31wrRw==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+    synckit "^0.9.1"
 
 eslint-plugin-prettier@^4.2.1:
   version "4.2.1"
@@ -13629,6 +13650,14 @@ swc-loader@^0.2.3:
   dependencies:
     "@swc/counter" "^0.1.3"
 
+synckit@^0.9.1:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.9.2.tgz#a3a935eca7922d48b9e7d6c61822ee6c3ae4ec62"
+  integrity sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==
+  dependencies:
+    "@pkgr/core" "^0.1.0"
+    tslib "^2.6.2"
+
 tailwind-merge@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.3.0.tgz#27d2134fd00a1f77eca22bcaafdd67055917d286"
@@ -13875,7 +13904,7 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.6
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
   integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
 
-tslib@^2.8.0:
+tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What Type of Change is this?

- [ ] New Page
- [x] Minor Fix
- [ ] Minor Improvement
- [ ] Major Improvement

#### Description (required)

The main point is to allow the docs development to run on the Windows platform, mainly the following two commands:

* npm run dev
* npm run lint:content

The supposed environment (tested):
* Node.js 18.20.3
* Yarn 1.22.22

Steps to run:
* clone the repository
* run the `yarn` command from the project root
* run `npm run dev` or `npm run lint:content`
