### PR TITLE
docs: fix --deploy-git-folder description + document buildFromGit constraints and startWithoutCode

### DIFF
--- a/apps/docs/content/features/pipeline.mdx
+++ b/apps/docs/content/features/pipeline.mdx
@@ -405,8 +405,8 @@ Usage:
 Flags:
       --archive-file-path string   If set, zCLI creates a tar.gz archive with the application code in the required path relative
                                  to the working directory. By default, no archive is created.
-      --deploy-git-folder          Sets a custom path to the zerops.yaml file relative to the working directory. By default zCLI
-                                 looks for zerops.yaml in the working directory.
+      --deploy-git-folder          If set, the .git folder is also uploaded with the deploy. By default, the .git folder
+                                 is ignored.
   -h, --help                     the service deploy command.
       --project-id string         If you have access to more than one project, you must specify the project ID for which the
                                  command is to be executed.

--- a/apps/docs/content/references/import.mdx
+++ b/apps/docs/content/references/import.mdx
@@ -412,8 +412,11 @@ This example includes all possible configuration options for Zerops services. No
       <td className="w-fit">
         Default: `false`<br/>
         Set `true` to start a runtime service's containers without waiting for a first
-        deploy. Useful for provisioning a service whose code arrives later (e.g. via
-        SSH or a later pipeline run).
+        deploy. Useful when the code arrives later (a subsequent pipeline run), or when
+        you want a live container to [SSH](/references/networking/ssh) into and play
+        around in — once your setup steps work, version them into
+        [`run.prepareCommands`](/zerops-yaml/specification#preparecommands--1) so they
+        persist across container replacements.
       </td>
     </tr>
     <tr>

--- a/apps/docs/content/references/import.mdx
+++ b/apps/docs/content/references/import.mdx
@@ -401,6 +401,19 @@ This example includes all possible configuration options for Zerops services. No
       <td className="w-fit">string (URL)</td>
       <td className="w-fit">
         A URL of a Github or Gitlab repository used for a one-time build of your service.
+        The repository must be publicly accessible — a private repository fails at clone
+        time (the build ends FAILED with no build log). Use the plain repository URL
+        without a trailing `.git` suffix, which fails the same way.
+      </td>
+    </tr>
+    <tr>
+      <td className="w-fit font-semibold">startWithoutCode</td>
+      <td className="w-fit">boolean</td>
+      <td className="w-fit">
+        Default: `false`<br/>
+        Set `true` to start a runtime service's containers without waiting for a first
+        deploy. Useful for provisioning a service whose code arrives later (e.g. via
+        SSH or a later pipeline run).
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## What

Three small reference fixes, each verified against the live platform / live `zcli`:

1. **`pipeline.mdx` — `--deploy-git-folder` flag description was wrong.** The `zcli service deploy` flag list described it as "Sets a custom path to the zerops.yaml file" — a copy of `--zerops-yaml-path`'s text two rows below. Per `zcli service deploy --help`, the flag actually uploads the `.git` folder with the deploy (ignored by default). Description corrected.

2. **`import.mdx` — `buildFromGit` constraints documented.** Two failure modes verified against the live platform, both ending in a terminal FAILED build with **no build log** (hard to diagnose without knowing them):
   - the repository must be publicly accessible — a private repo fails at clone time;
   - a trailing `.git` suffix on the URL (the conventional clone-URL form) fails the same way.

3. **`import.mdx` — `startWithoutCode` service key added.** Present in the live import JSON schema (`Set true, if you want to start service without code.`) but previously undocumented. Added a table row: starts a runtime service's containers without waiting for a first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)