### PR TITLE
chore(guides): platform-accuracy fixes — dead options + run.mount drift

### DIFF
--- a/apps/docs/content/guides/choose-cache.mdx
+++ b/apps/docs/content/guides/choose-cache.mdx
@@ -10,7 +10,6 @@ description: "**Use Valkey.** KeyDB development has stalled and is effectively d
 | Need | Choice | Why |
 |------|--------|-----|
 | **Any caching need** | **Valkey** (default) | Active development, optional HA, Redis-compatible |
-| Legacy KeyDB apps | KeyDB | Only if migrating existing KeyDB deployment |
 
 ## Valkey (Default Choice)
 

--- a/apps/docs/content/guides/choose-search.mdx
+++ b/apps/docs/content/guides/choose-search.mdx
@@ -3,16 +3,16 @@ title: "Choosing a Search Engine on Zerops"
 description: "**Use Meilisearch** for simple full-text search. Use **Elasticsearch** for advanced queries or HA requirements. Use **Qdrant** for vector/AI search."
 ---
 
-**Use Meilisearch** for simple full-text search. Use **Elasticsearch** for advanced queries or HA requirements. Use **Qdrant** for vector/AI search.
+Four managed search engines, chosen by workload. **Meilisearch** for simple full-text search (the default). **Elasticsearch** for advanced queries or HA full-text. **Typesense** for autocomplete with typo-tolerance (HA-capable). **Qdrant** for vector / AI similarity search.
 
 ## Decision Matrix
 
 | Need | Choice | Why |
 |------|--------|-----|
-| **Simple full-text search** | **Meilisearch** (default) | Instant setup, typo-tolerant, frontend-safe keys |
-| Advanced queries / HA | Elasticsearch | Cluster support, plugins, JVM tuning |
-| Autocomplete + typo-tolerance | Typesense | Raft HA, CORS built-in, fast |
-| Vector / AI similarity | Qdrant | gRPC + HTTP, automatic cluster replication |
+| Simple full-text search (default) | **Meilisearch** | Instant setup, typo-tolerant, frontend-safe keys; single-node only (no HA) |
+| Advanced queries / HA full-text | **Elasticsearch** | Multi-node cluster, plugins, JVM tuning |
+| Autocomplete + typo-tolerance, with HA | **Typesense** | 3-node Raft consensus, CORS built-in, fast |
+| Vector / AI similarity | **Qdrant** | HTTP + gRPC, automatic cluster replication; internal-only |
 
 ## Meilisearch (Default for Simple Search)
 

--- a/apps/docs/content/guides/deployment-lifecycle.mdx
+++ b/apps/docs/content/guides/deployment-lifecycle.mdx
@@ -138,4 +138,4 @@ When using SSHFS (`zerops_mount`) for dev workflows, deploy replaces the contain
 
 **Two kinds of "mount" (disambiguation):**
 - `zerops_mount` -- SSHFS tool, mounts service `/var/www` locally for development. This is a dev workflow tool.
-- Shared storage mount -- platform feature, attaches a shared-storage volume at `/mnt/{hostname}` via `mount:` in import.yml + zerops.yml `run.mount`. These are completely unrelated features.
+- Shared storage mount -- platform feature, attaches a shared-storage volume at `/mnt/{hostname}` via the service-level `mount:` parameter in import.yml. There is no `mount` field in zerops.yml (a `run.mount` is silently ignored). These are completely unrelated features.

--- a/apps/docs/content/guides/production-checklist.mdx
+++ b/apps/docs/content/guides/production-checklist.mdx
@@ -3,7 +3,7 @@ title: "Production Checklist for Zerops"
 description: "Before going to production: (1) databases to HA mode, (2) minContainers: 2 on app services, (3) replace Mailpit with real SMTP, (4) remove Adminer, (5) use Object Storage for uploads, (6) use Redis/Valkey for sessions."
 ---
 
-Before going to production: (1) databases to HA mode, (2) minContainers: 2 on app services, (3) replace Mailpit with real SMTP, (4) remove Adminer, (5) use Object Storage for uploads, (6) use Redis/Valkey for sessions.
+Before going to production: (1) databases to HA mode, (2) minContainers: 2 on app services, (3) replace Mailpit with real SMTP, (4) remove Adminer, (5) use Object Storage for uploads, (6) use Valkey for sessions.
 
 ## Database
 
@@ -83,7 +83,7 @@ Remove entirely or disable `enableSubdomainAccess`. Use VPN + pgAdmin/DBeaver lo
 
 | Use case | Solution |
 |----------|----------|
-| PHP sessions | Redis/Valkey |
+| PHP sessions | Valkey |
 | Laravel sessions | Redis driver |
 | Django sessions | Redis backend |
 | Express sessions | Redis store |

--- a/apps/docs/content/guides/scaling.mdx
+++ b/apps/docs/content/guides/scaling.mdx
@@ -21,7 +21,7 @@ Zerops autoscales vertically (CPU/RAM/disk) and horizontally (container count). 
 | **Runtime** (Node.js, Go, PHP, Python, Java, etc.) | Yes | Yes (1-10 containers) | Full autoscaling |
 | **Linux containers** (Alpine, Ubuntu) | Yes | Yes (1-10 containers) | Same as runtimes |
 | **Managed DB** (PostgreSQL, MariaDB) | Yes | No (fixed: NON_HA=1, HA=3) | Mode immutable after creation |
-| **Managed cache** (KeyDB/Valkey) | Yes | No (fixed: NON_HA=1, HA=3) | Mode immutable after creation |
+| **Managed cache** (Valkey) | Yes | No (fixed: NON_HA=1, HA=3) | Mode immutable after creation |
 | **Shared storage** | Yes (cpu/ram/disk configurable) | No (fixed: NON_HA=1, HA=3) | Accepts verticalAutoscaling in import.yml |
 | **Object storage** | No | No | Fixed size at creation, no verticalAutoscaling |
 | **Docker** | No (manual, triggers VM restart) | Manual only (change VM count, triggers restart) | No automatic autoscaling |


### PR DESCRIPTION
Platform-accuracy fixes across 5 guides, each verified against the live Zerops import / zerops.yml JSON schemas. Surfaced by a ZCP knowledge investigation (a Typesense query was being read as "not a managed service").

- **choose-search** — the lead named only 3 of the 4 managed search engines (Typesense was missing from the headline, relegated to the matrix). Now names all four (Meilisearch / Elasticsearch / Typesense / Qdrant); matrix surfaces each engine's disqualifying constraint inline.
- **choose-cache** — removed the KeyDB matrix row. KeyDB is no longer offerable (absent from the live import schema; only `valkey:ha@7.2` / `valkey:single@7.2` exist for caching). Presenting it as a pickable Choice cell surfaced a dead option an agent would try to import and fail. Deprecation prose in the lead is kept.
- **production-checklist** — "Redis/Valkey" → "Valkey" in the sessions line + table. Redis is not an offerable managed type on Zerops (redis → valkey). Framework-driver mentions (Laravel/Django/Express "Redis driver/backend/store") left intact — those name the redis-protocol driver Valkey serves.
- **scaling** — "Managed cache (KeyDB/Valkey)" → "(Valkey)", same dead-option reason.
- **deployment-lifecycle** — corrected a fabricated `zerops.yml run.mount`. The zerops.yml schema has no `mount` field; the only shared-storage mount mechanism is the service-level `mount:` in import.yaml.

Generated from ZCP via `sync push guides`.