### PR TITLE
docs(guides): recommend conservative scaling profile per tier (dev hobby, prod staging)

### DIFF
--- a/apps/docs/content/guides/choose-cache.mdx
+++ b/apps/docs/content/guides/choose-cache.mdx
@@ -15,5 +15,5 @@ description: "**Use Valkey.** KeyDB development has stalled and is effectively d
 
 - Redis-compatible drop-in replacement
 - Type: `valkey:single@7.2` (single) or `valkey:ha@7.2` (HA) — only v7.2 is supported (the platform rejects `valkey@8` at import, `serviceStackTypeNotFound`)
-- Profile (scaling tier): `hobby` for dev (lowest cost), `staging` (default), or `production`
+- Profile (scaling tier): `hobby` for dev, `staging` for production; escalate to `production` only on a clear load signal
 - Connection: `redis://${hostname}:6379` — Valkey runs **unauthenticated** on Zerops; there are NO `user`/`password` env vars. Do **not** template `${cache_user}`/`${cache_password}` — they don't exist and produce a broken DSN

--- a/apps/docs/content/guides/choose-database.mdx
+++ b/apps/docs/content/guides/choose-database.mdx
@@ -15,7 +15,7 @@ description: "**Use PostgreSQL** for everything unless you have a specific reaso
 
 ## PostgreSQL (Default Choice)
 
-- Type + scaling: `postgresql:single@<ver>` (single node, dev) or `postgresql:ha@<ver>` (HA cluster). Add a `profile` (scaling tier): `oltp-hobby` for dev — lowest cost — up to `oltp-production` / `oltp-enterprise` for production. Omitting it applies the default (single → `oltp-staging`, HA → `oltp-production`). See [PostgreSQL scaling](/postgresql/how-to/scale)
+- Type + scaling: `postgresql:single@<ver>` (single node, dev) or `postgresql:ha@<ver>` (HA cluster). Add a `profile` (scaling tier) — set it explicitly and escalate only on a clear signal: `oltp-hobby` for dev, `oltp-staging` for production, moving up to `oltp-production` / `oltp-enterprise` only when load clearly needs it. Omitting it applies the default (single → `oltp-staging`, HA → `oltp-production` = dedicated CPU). See [PostgreSQL scaling](/postgresql/how-to/scale)
 - Connection: the generated `${connectionString}` is `postgresql://${user}:${password}@${hostname}:5432` (no database path). Append `/${dbName}` yourself if your driver needs one — the db-name var is `dbName` (default `db`)
 
 ## MariaDB


### PR DESCRIPTION
Follow-up to #354. Recommend setting the PostgreSQL/Valkey `profile` explicitly and **escalating only on a clear signal**: dev → `oltp-hobby` / `hobby`, production → `oltp-staging` / `staging`; move up to `oltp-production`/`oltp-enterprise` (pg) or `production` (valkey) only when load clearly needs it. Avoids the HA omit-default (`oltp-production` = dedicated CPU) over-provisioning. Touches choose-database + choose-cache.