### PR TITLE
Fix color mode ignoring docusaurus-theme URL param

### DIFF
--- a/packages/docs-ui/src/providers/ColorMode/index.tsx
+++ b/packages/docs-ui/src/providers/ColorMode/index.tsx
@@ -28,7 +28,10 @@ export const ColorModeProvider = ({ children }: ColorModeProviderProps) => {
       return;
     }
 
-    const theme = localStorage.getItem('theme');
+    const urlTheme = new URLSearchParams(window.location.search).get(
+      'docusaurus-theme'
+    );
+    const theme = urlTheme ?? localStorage.getItem('theme');
     if (theme && (theme === 'light' || theme === 'dark')) {
       setColorMode(theme);
     } else {


### PR DESCRIPTION
#### What Type of Change is this?

- [x] Minor Fix

#### Description (required)

The color-mode provider only read the persisted theme from `localStorage` on mount, so a `?docusaurus-theme=` query param was silently ignored and the page always defaulted to light mode. The URL param now takes priority, falling back to `localStorage`, then light.

#### Related issues & labels (optional)

- /closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV4vQhfyNV57p28BJMeGoq